### PR TITLE
If a key is not supplied to the get function, return the entire user settings object

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,11 @@ function DotConfig(filepath) {
 
 	this.get = function(key) {
 		options = options || readFile(filepath);
+
+		if (!key) {
+			return options;
+		}
+
 		if (key in options) {
 			return options[key];
 		} else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-settings",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "Simple user settings management",
   "main": "dots.js",
   "scripts": {


### PR DESCRIPTION
I found myself in a situation where I wanted to retrieve all of a users settings