### PR TITLE
Respect absolute filepaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ settings.unset('username');
 
 ```
 
+Settings file location can be customized by passing in an absolute filepath:
+
+```js
+// Store settings in the process root.  Useful for directory-specific configurations.
+var path = require('path')
+var settings = require('user-settings').file(path.resolve(process.cwd(), '.myAppSettings))
+```
+
 ## Home directory location
 
 The home directory used for Unix systems is `process.env.HOME` and `process.env.USERPROFILE` for Windows.


### PR DESCRIPTION
I'm using user-settings to build in some user settings into a CLI I'm working on, but my tool might be used across multiple project instances (directories), and the configuration needs to be local to each directory.

I thought it'd be a nice low-impact change to allow the user to pass in absolute file paths if they need to customize the file location.

I threw in a section on the readme to call out this option.